### PR TITLE
Add PseudoSeed node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -59,6 +59,9 @@ NODE_CLASS_MAPPINGS = {
     "PseudoVarFloat": PseudoVarFloat,
     "PseudoVarInt": PseudoVarInt,
     "PseudoVarString": PseudoVarString,
+
+    # seed
+    "PseudoSeed": PseudoSeed,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -98,4 +101,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "PseudoVarFloat": "Float Variable",
     "PseudoVarInt": "Int Variable",
     "PseudoVarString": "String Variable",
+
+    # seed
+    "PseudoSeed": "Seed",
 }

--- a/node_vars.py
+++ b/node_vars.py
@@ -89,3 +89,44 @@ class PseudoVarString:
         print(f"[pseudocomfy] PseudoVarString: {s}")
         return (s,)
 
+
+class PseudoSeed:
+    """
+    Seed node. Produces an integer seed value to feed noise/sampling.
+
+    Unlike the PseudoVar* nodes this is not a variable: it is meant to be
+    dropped onto the canvas wherever a seed is needed and driven externally
+    (e.g. by the Pseudorandom Rhino plugin) rather than hand edited.
+
+    The widget is named "seed" so ComfyUI automatically attaches its
+    standard control_after_generate (fixed / increment / decrement /
+    randomize) behaviour, and so external tooling can set the value via the
+    node's widgets_values in the submitted workflow.
+
+    Inputs:
+        seed (int): The seed value (0 .. 2**64 - 1).
+    Outputs:
+        seed (int): The seed value, passed through.
+    """
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "seed": ("INT", {
+                    "default": 0,
+                    "min": 0,
+                    "max": 0xffffffffffffffff
+                })
+            },
+        }
+
+    RETURN_TYPES = ("INT",)
+    RETURN_NAMES = ("seed",)
+    FUNCTION = "func"
+    CATEGORY = "Pseudocomfy/Vars"
+
+    def func(self, seed):
+        seed = int(seed)
+        print(f"[pseudocomfy] PseudoSeed: {seed}")
+        return (seed,)
+


### PR DESCRIPTION
This PR intends to create a PseudoSeed node within the Pseudocomfy extension in ComfyUI. The new seed source (int, 0..2**64-1) node is driven by the Pseudorandom Rhino plugin. The widget is named "seed" so ComfyUI attaches its standard control_after_generate behaviour. Users are expected to add 1+ of these nodes within their workflow to tune their images similarly.