### PR TITLE
Add pseudovettedcheckpointloader

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,7 +28,7 @@ NODE_CLASS_MAPPINGS = {
     # loaders
     "PseudoLoadModelSnapshot": PseudoLoadModelSnapshot,
     "PseudoUnpackModelSnapshot": PseudoUnpackModelSnapshot,
-    "PseudoVettedModelLoader": PseudoVettedModelLoader,
+    "PseudoVettedCheckpointLoader": PseudoVettedCheckpointLoader,
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": PseudoSaveImageWithEmbeddedMasks,
@@ -71,7 +71,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     # loaders
     "PseudoLoadModelSnapshot": "Load Model Snapshot",
     "PseudoUnpackModelSnapshot": "Unpack Model Snapshot",
-    "PseudoVettedModelLoader": "Vetted Model Loader",
+    "PseudoVettedCheckpointLoader": "Vetted Checkpoint Loader",
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": "Save Image with Embedded Masks",

--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,7 @@ from .node_conditioning import *
 from .node_io import *
 from .node_ipadapter_loader import *
 from .node_loaders_snapshot import *
+from .node_loaders_vetted import *
 from .node_processing import *
 from .node_utils import *
 from .node_vars import *
@@ -27,6 +28,7 @@ NODE_CLASS_MAPPINGS = {
     # loaders
     "PseudoLoadModelSnapshot": PseudoLoadModelSnapshot,
     "PseudoUnpackModelSnapshot": PseudoUnpackModelSnapshot,
+    "PseudoVettedModelLoader": PseudoVettedModelLoader,
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": PseudoSaveImageWithEmbeddedMasks,
@@ -69,6 +71,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     # loaders
     "PseudoLoadModelSnapshot": "Load Model Snapshot",
     "PseudoUnpackModelSnapshot": "Unpack Model Snapshot",
+    "PseudoVettedModelLoader": "Vetted Model Loader",
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": "Save Image with Embedded Masks",

--- a/node_loaders_vetted.py
+++ b/node_loaders_vetted.py
@@ -1,0 +1,88 @@
+import requests
+
+
+SUPABASE_URL = "https://psfxsrilludczykwdyxz.supabase.co/rest/v1"
+
+# This is the Supabase anon key — intentionally public-facing. Access is
+# governed by Row Level Security policies on the Supabase side.
+SUPABASE_ANON_KEY = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBzZnhzcmlsbHVkY3p5a3dkeXh6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODM1NDMwNDgsImV4cCI6MjA5OTExOTA0OH0"
+    ".WewS_QERP0nhd9O7uIXQ0evKhfjci04QCGBHJeH8pLk"
+)
+
+_CATEGORY_NAMES = {
+    1: "checkpoints",
+    2: "clip_vision",
+    3: "controlnet",
+    4: "ipadapter",
+    5: "loras",
+}
+
+
+def _fetch_vetted_models():
+    try:
+        response = requests.get(
+            f"{SUPABASE_URL}/models",
+            headers={
+                "apikey": SUPABASE_ANON_KEY,
+                "Authorization": f"Bearer {SUPABASE_ANON_KEY}",
+            },
+            params={
+                "select": "name,file_name,category_id",
+                "vetting_status_id": "eq.3",
+                "order": "name",
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        print(f"[pseudocomfy] PseudoVettedModelLoader: failed to fetch models: {e}")
+        return []
+
+
+_VETTED_MODELS = _fetch_vetted_models()
+
+_MODEL_LOOKUP = {
+    m["name"]: (m["file_name"], _CATEGORY_NAMES.get(m["category_id"], "unknown"))
+    for m in _VETTED_MODELS
+}
+
+_MODEL_NAMES = list(_MODEL_LOOKUP.keys()) or ["(no vetted models available)"]
+
+
+class PseudoVettedModelLoader:
+    """
+    Presents a dropdown of vetted models from the Pseudorandom Supabase database.
+    The list is fetched once at server startup.
+
+    Unlike the standard ComfyUI loader nodes, this does not load the model file
+    itself — it outputs the filename and category as strings so they can be wired
+    into whichever standard loader node is appropriate (Load Checkpoint, Load
+    ControlNet Model, etc.).
+
+    Inputs:
+        model (str): Selected model display name from the dropdown.
+    Outputs:
+        file_name (str): The model filename (e.g. "sd_xl_base_1.0.safetensors").
+        category (str): The model category (e.g. "checkpoints", "loras", "controlnet").
+    """
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": (_MODEL_NAMES, {}),
+            },
+        }
+
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("file_name", "category")
+    FUNCTION = "func"
+    CATEGORY = "Pseudocomfy/Loaders"
+
+    def func(self, model):
+        file_name, category = _MODEL_LOOKUP.get(model, (model, "unknown"))
+        print(f"[pseudocomfy] PseudoVettedModelLoader: {model} → {file_name} ({category})")
+        return (file_name, category)

--- a/node_loaders_vetted.py
+++ b/node_loaders_vetted.py
@@ -1,4 +1,6 @@
 import requests
+import folder_paths
+import comfy.sd
 
 
 SUPABASE_URL = "https://psfxsrilludczykwdyxz.supabase.co/rest/v1"
@@ -10,14 +12,6 @@ SUPABASE_ANON_KEY = (
     ".eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InBzZnhzcmlsbHVkY3p5a3dkeXh6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODM1NDMwNDgsImV4cCI6MjA5OTExOTA0OH0"
     ".WewS_QERP0nhd9O7uIXQ0evKhfjci04QCGBHJeH8pLk"
 )
-
-_CATEGORY_NAMES = {
-    1: "checkpoints",
-    2: "clip_vision",
-    3: "controlnet",
-    4: "ipadapter",
-    5: "loras",
-}
 
 
 def _fetch_vetted_models():
@@ -38,51 +32,37 @@ def _fetch_vetted_models():
         response.raise_for_status()
         return response.json()
     except Exception as e:
-        print(f"[pseudocomfy] PseudoVettedModelLoader: failed to fetch models: {e}")
+        print(f"[pseudocomfy] failed to fetch vetted models: {e}")
         return []
 
 
 _VETTED_MODELS = _fetch_vetted_models()
 
-_MODEL_LOOKUP = {
-    m["name"]: (m["file_name"], _CATEGORY_NAMES.get(m["category_id"], "unknown"))
-    for m in _VETTED_MODELS
-}
-
-_MODEL_NAMES = list(_MODEL_LOOKUP.keys()) or ["(no vetted models available)"]
+_CHECKPOINT_MODELS = [m for m in _VETTED_MODELS if m["category_id"] == 1]
+_CHECKPOINT_NAMES = [m["file_name"] for m in _CHECKPOINT_MODELS] or ["(no vetted checkpoints available)"]
 
 
-class PseudoVettedModelLoader:
-    """
-    Presents a dropdown of vetted models from the Pseudorandom Supabase database.
-    The list is fetched once at server startup.
-
-    Unlike the standard ComfyUI loader nodes, this does not load the model file
-    itself — it outputs the filename and category as strings so they can be wired
-    into whichever standard loader node is appropriate (Load Checkpoint, Load
-    ControlNet Model, etc.).
-
-    Inputs:
-        model (str): Selected model display name from the dropdown.
-    Outputs:
-        file_name (str): The model filename (e.g. "sd_xl_base_1.0.safetensors").
-        category (str): The model category (e.g. "checkpoints", "loras", "controlnet").
-    """
-
+class PseudoVettedCheckpointLoader:
     @classmethod
     def INPUT_TYPES(s):
         return {
             "required": {
-                "model": (_MODEL_NAMES, {}),
+                "model": (_CHECKPOINT_NAMES, {}),
             },
         }
 
-    RETURN_TYPES = ("STRING", "STRING")
-    RETURN_NAMES = ("file_name", "category")
+    RETURN_TYPES = ("MODEL", "CLIP", "VAE")
+    RETURN_NAMES = ("model", "clip", "vae")
     FUNCTION = "func"
     CATEGORY = "Pseudocomfy/Loaders"
 
     def func(self, model):
-        file_name, category = _MODEL_LOOKUP.get(model, (model, "unknown"))
-        print(f"[pseudocomfy] PseudoVettedModelLoader: {model} → {file_name} ({category})")
-        return (file_name, category)
+        ckpt_path = folder_paths.get_full_path_or_raise("checkpoints", model)
+        out = comfy.sd.load_checkpoint_guess_config(
+            ckpt_path,
+            output_vae=True,
+            output_clip=True,
+            embedding_directory=folder_paths.get_folder_paths("embeddings"),
+        )
+        print(f"[pseudocomfy] PseudoVettedCheckpointLoader: {model}")
+        return out[:3]


### PR DESCRIPTION
This adds the new PseudoVettedCheckpointLoader node. It populates the checkpoint models from the database when ComfyUI is first loaded only. The user can select a checkpoint model from the list. They can connect the 'model', "vae', 'clip' outputs. 

When the working file is exported API as json, the filename is in inputs.model. This is what the wizard will check against to find the model in the database and find the provenance details. 

(The node doesn't pass in the model's UUID. This might be a later feature to add the model ID if we are ok with the ID being displayed on the frontend of the node within the ComfyUI canvas)