### PR TITLE
Add PseudoVettedControlNetLoader node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -29,6 +29,7 @@ NODE_CLASS_MAPPINGS = {
     "PseudoLoadModelSnapshot": PseudoLoadModelSnapshot,
     "PseudoUnpackModelSnapshot": PseudoUnpackModelSnapshot,
     "PseudoVettedCheckpointLoader": PseudoVettedCheckpointLoader,
+    "PseudoVettedControlNetLoader": PseudoVettedControlNetLoader,
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": PseudoSaveImageWithEmbeddedMasks,
@@ -72,6 +73,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "PseudoLoadModelSnapshot": "Load Model Snapshot",
     "PseudoUnpackModelSnapshot": "Unpack Model Snapshot",
     "PseudoVettedCheckpointLoader": "Vetted Checkpoint Loader",
+    "PseudoVettedControlNetLoader": "Vetted ControlNet Loader",
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": "Save Image with Embedded Masks",

--- a/node_loaders_vetted.py
+++ b/node_loaders_vetted.py
@@ -1,6 +1,7 @@
 import requests
 import folder_paths
 import comfy.sd
+import comfy.controlnet
 
 
 SUPABASE_URL = "https://psfxsrilludczykwdyxz.supabase.co/rest/v1"
@@ -41,6 +42,11 @@ _VETTED_MODELS = _fetch_vetted_models()
 _CHECKPOINT_MODELS = [m for m in _VETTED_MODELS if m["category_id"] == 1]
 _CHECKPOINT_NAMES = [m["file_name"] for m in _CHECKPOINT_MODELS] or ["(no vetted checkpoints available)"]
 
+_CONTROLNET_NAMES = (
+    [m["file_name"] for m in _VETTED_MODELS if m["category_id"] == 3]
+    or ["(no vetted controlnet models available)"]
+)
+
 
 class PseudoVettedCheckpointLoader:
     @classmethod
@@ -66,3 +72,26 @@ class PseudoVettedCheckpointLoader:
         )
         print(f"[pseudocomfy] PseudoVettedCheckpointLoader: {model}")
         return out[:3]
+
+
+class PseudoVettedControlNetLoader:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": (_CONTROLNET_NAMES, {}),
+            },
+        }
+
+    RETURN_TYPES = ("CONTROL_NET",)
+    RETURN_NAMES = ("control_net",)
+    FUNCTION = "func"
+    CATEGORY = "Pseudocomfy/Loaders"
+
+    def func(self, model):
+        controlnet_path = folder_paths.get_full_path_or_raise("controlnet", model)
+        controlnet = comfy.controlnet.load_controlnet(controlnet_path)
+        if controlnet is None:
+            raise RuntimeError(f"[pseudocomfy] PseudoVettedControlNetLoader: invalid controlnet file: {model}")
+        print(f"[pseudocomfy] PseudoVettedControlNetLoader: {model}")
+        return (controlnet,)


### PR DESCRIPTION
Fetches vetted ControlNet models (category_id=3) from the Pseudorandom Supabase database at server startup, presents filenames in a COMBO dropdown, and loads the model — outputting CONTROL_NET like the standard Load ControlNet Model node.

This adds the new PseudoVettedControlNetLoader node. It populates the checkpoint models from the database when ComfyUI is first loaded only. The user can select a checkpoint model from the list. They can connect the 'control_net' outputs.

When the working file is exported API as json, the filename is inputs.model. This is what the wizard will check against to find the model in the database and find the provenance details.

(The node doesn't pass in the model's UUID. This might be a later feature to add the model ID if we are ok with the ID being displayed on the frontend of the node within the ComfyUI canvas)