### PR TITLE
Add pseudovettedloraloader

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -30,6 +30,7 @@ NODE_CLASS_MAPPINGS = {
     "PseudoUnpackModelSnapshot": PseudoUnpackModelSnapshot,
     "PseudoVettedCheckpointLoader": PseudoVettedCheckpointLoader,
     "PseudoVettedControlNetLoader": PseudoVettedControlNetLoader,
+    "PseudoVettedLoraLoader": PseudoVettedLoraLoader,
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": PseudoSaveImageWithEmbeddedMasks,
@@ -74,6 +75,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "PseudoUnpackModelSnapshot": "Unpack Model Snapshot",
     "PseudoVettedCheckpointLoader": "Vetted Checkpoint Loader",
     "PseudoVettedControlNetLoader": "Vetted ControlNet Loader",
+    "PseudoVettedLoraLoader": "Vetted LoRA Loader",
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": "Save Image with Embedded Masks",

--- a/node_loaders_vetted.py
+++ b/node_loaders_vetted.py
@@ -2,6 +2,7 @@ import requests
 import folder_paths
 import comfy.sd
 import comfy.controlnet
+import comfy.utils
 
 
 SUPABASE_URL = "https://psfxsrilludczykwdyxz.supabase.co/rest/v1"
@@ -45,6 +46,11 @@ _CHECKPOINT_NAMES = [m["file_name"] for m in _CHECKPOINT_MODELS] or ["(no vetted
 _CONTROLNET_NAMES = (
     [m["file_name"] for m in _VETTED_MODELS if m["category_id"] == 3]
     or ["(no vetted controlnet models available)"]
+)
+
+_LORA_NAMES = (
+    [m["file_name"] for m in _VETTED_MODELS if m["category_id"] == 5]
+    or ["(no vetted lora models available)"]
 )
 
 
@@ -95,3 +101,39 @@ class PseudoVettedControlNetLoader:
             raise RuntimeError(f"[pseudocomfy] PseudoVettedControlNetLoader: invalid controlnet file: {model}")
         print(f"[pseudocomfy] PseudoVettedControlNetLoader: {model}")
         return (controlnet,)
+
+
+class PseudoVettedLoraLoader:
+    def __init__(self):
+        self.loaded_lora = None
+
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "lora": (_LORA_NAMES, {}),
+                "strength_model": ("FLOAT", {"default": 1.0, "min": -100.0, "max": 100.0, "step": 0.01}),
+            },
+        }
+
+    RETURN_TYPES = ("MODEL",)
+    RETURN_NAMES = ("model",)
+    FUNCTION = "func"
+    CATEGORY = "Pseudocomfy/Loaders"
+
+    def func(self, model, lora, strength_model):
+        if strength_model == 0:
+            return (model,)
+
+        lora_path = folder_paths.get_full_path_or_raise("loras", lora)
+
+        if self.loaded_lora is not None and self.loaded_lora[0] == lora_path:
+            lora_weights, lora_metadata = self.loaded_lora[1], self.loaded_lora[2]
+        else:
+            lora_weights, lora_metadata = comfy.utils.load_torch_file(lora_path, safe_load=True, return_metadata=True)
+            self.loaded_lora = (lora_path, lora_weights, lora_metadata)
+
+        model_out, _ = comfy.sd.load_lora_for_models(model, None, lora_weights, strength_model, 0, lora_metadata=lora_metadata)
+        print(f"[pseudocomfy] PseudoVettedLoraLoader: {lora} (strength: {strength_model})")
+        return (model_out,)


### PR DESCRIPTION
This adds the new PseudoVettedLoraLoader node. It populates the LoRA models from the database when ComfyUI is first loaded only. The user can select a LoRA model from the list. They can connect the 'model' output.

When the working file is exported API as json, the filename is inputs.model. This is what the wizard will check against to find the model in the database and find the provenance details.

(The node doesn't pass in the model's UUID. This might be a later feature to add the model ID if we are ok with the ID being displayed on the frontend of the node within the ComfyUI canvas)