### PR TITLE
Add PseudoVettedClipVisionLoader node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,7 @@ NODE_CLASS_MAPPINGS = {
     "PseudoVettedCheckpointLoader": PseudoVettedCheckpointLoader,
     "PseudoVettedControlNetLoader": PseudoVettedControlNetLoader,
     "PseudoVettedLoraLoader": PseudoVettedLoraLoader,
+    "PseudoVettedClipLoader": PseudoVettedClipLoader,
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": PseudoSaveImageWithEmbeddedMasks,
@@ -76,6 +77,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "PseudoVettedCheckpointLoader": "Vetted Checkpoint Loader",
     "PseudoVettedControlNetLoader": "Vetted ControlNet Loader",
     "PseudoVettedLoraLoader": "Vetted LoRA Loader",
+    "PseudoVettedClipLoader": "Vetted CLIP Loader",
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": "Save Image with Embedded Masks",

--- a/node_loaders_vetted.py
+++ b/node_loaders_vetted.py
@@ -1,4 +1,5 @@
 import requests
+import torch
 import folder_paths
 import comfy.sd
 import comfy.controlnet
@@ -51,6 +52,11 @@ _CONTROLNET_NAMES = (
 _LORA_NAMES = (
     [m["file_name"] for m in _VETTED_MODELS if m["category_id"] == 5]
     or ["(no vetted lora models available)"]
+)
+
+_CLIP_NAMES = (
+    [m["file_name"] for m in _VETTED_MODELS if m["category_id"] == 7]
+    or ["(no vetted CLIP models available)"]
 )
 
 
@@ -137,3 +143,45 @@ class PseudoVettedLoraLoader:
         model_out, _ = comfy.sd.load_lora_for_models(model, None, lora_weights, strength_model, 0, lora_metadata=lora_metadata)
         print(f"[pseudocomfy] PseudoVettedLoraLoader: {lora} (strength: {strength_model})")
         return (model_out,)
+
+
+class PseudoVettedClipLoader:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": (_CLIP_NAMES, {}),
+                "type": (["stable_diffusion", "stable_cascade", "sd3", "flux"], {}),
+                "device": (["default", "cpu"], {"advanced": True}),
+            },
+        }
+
+    RETURN_TYPES = ("CLIP",)
+    RETURN_NAMES = ("clip",)
+    FUNCTION = "func"
+    CATEGORY = "Pseudocomfy/Loaders"
+
+    def func(self, model, type="stable_diffusion", device="default"):
+        if model == "(no vetted CLIP models available)":
+            raise RuntimeError("[pseudocomfy] PseudoVettedClipLoader: no vetted CLIP models available in the database.")
+
+        clip_type_map = {
+            "stable_cascade": comfy.sd.CLIPType.STABLE_CASCADE,
+            "sd3": comfy.sd.CLIPType.SD3,
+            "flux": comfy.sd.CLIPType.FLUX,
+        }
+        clip_type = clip_type_map.get(type, comfy.sd.CLIPType.STABLE_DIFFUSION)
+
+        model_options = {}
+        if device == "cpu":
+            model_options["load_device"] = model_options["offload_device"] = torch.device("cpu")
+
+        clip_path = folder_paths.get_full_path_or_raise("clip", model)
+        clip = comfy.sd.load_clip(
+            ckpt_paths=[clip_path],
+            embedding_directory=folder_paths.get_folder_paths("embeddings"),
+            clip_type=clip_type,
+            model_options=model_options,
+        )
+        print(f"[pseudocomfy] PseudoVettedClipLoader: {model}")
+        return (clip,)


### PR DESCRIPTION
Fetches vetted CLIP Vision models (category_id=2) from the Pseudorandom Supabase database at server startup, presents filenames in a COMBO dropdown, and loads the model, outputting CLIP_VISION like the ComfyUI Load CLIP Vision node.

When the working file is exported API as json, the filename is inputs.model. This is what the wizard will check against to find the model in the database and find the provenance details.

(The node doesn't pass in the model's UUID. This might be a later feature to add the model ID if we are ok with the ID being displayed on the frontend of the node within the ComfyUI canvas)