### PR TITLE
Add vae node

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,6 +32,7 @@ NODE_CLASS_MAPPINGS = {
     "PseudoVettedControlNetLoader": PseudoVettedControlNetLoader,
     "PseudoVettedLoraLoader": PseudoVettedLoraLoader,
     "PseudoVettedClipLoader": PseudoVettedClipLoader,
+    "PseudoVettedVaeLoader": PseudoVettedVaeLoader,
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": PseudoSaveImageWithEmbeddedMasks,
@@ -78,6 +79,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "PseudoVettedControlNetLoader": "Vetted ControlNet Loader",
     "PseudoVettedLoraLoader": "Vetted LoRA Loader",
     "PseudoVettedClipLoader": "Vetted CLIP Loader",
+    "PseudoVettedVaeLoader": "Vetted VAE Loader",
 
     # io
     "PseudoSaveImageWithEmbeddedMasks": "Save Image with Embedded Masks",

--- a/node_loaders_vetted.py
+++ b/node_loaders_vetted.py
@@ -59,6 +59,11 @@ _CLIP_NAMES = (
     or ["(no vetted CLIP models available)"]
 )
 
+_VAE_NAMES = (
+    [m["file_name"] for m in _VETTED_MODELS if m["category_id"] == 6]
+    or ["(no vetted VAE models available)"]
+)
+
 
 class PseudoVettedCheckpointLoader:
     @classmethod
@@ -185,3 +190,24 @@ class PseudoVettedClipLoader:
         )
         print(f"[pseudocomfy] PseudoVettedClipLoader: {model}")
         return (clip,)
+
+
+class PseudoVettedVaeLoader:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {"required": {"model": (_VAE_NAMES, {})}}
+
+    RETURN_TYPES = ("VAE",)
+    RETURN_NAMES = ("vae",)
+    FUNCTION = "func"
+    CATEGORY = "Pseudocomfy/Loaders"
+
+    def func(self, model):
+        if model == "(no vetted VAE models available)":
+            raise RuntimeError("[pseudocomfy] PseudoVettedVaeLoader: no vetted VAE models available in the database.")
+        vae_path = folder_paths.get_full_path_or_raise("vae", model)
+        sd, metadata = comfy.utils.load_torch_file(vae_path, return_metadata=True)
+        vae = comfy.sd.VAE(sd=sd, metadata=metadata)
+        vae.throw_exception_if_invalid()
+        print(f"[pseudocomfy] PseudoVettedVaeLoader: {model}")
+        return (vae,)


### PR DESCRIPTION
Fetches vetted VAE models (category_id=6) from the Pseudorandom Supabase database at server startup, presents filenames in a COMBO dropdown, and loads the model, outputting vae like the ComfyUI Load VAE node.

When the working file is exported API as json, the filename is inputs.model. This is what the wizard will check against to find the model in the database and find the provenance details.

(The node doesn't pass in the model's UUID. This might be a later feature to add the model ID if we are ok with the ID being displayed on the frontend of the node within the ComfyUI canvas)