### PR TITLE
Refine IPAdapter presets to SDXL-only and non-face options

### DIFF
--- a/node_ipadapter_loader.py
+++ b/node_ipadapter_loader.py
@@ -30,7 +30,7 @@ class PseudoIPAdapterUnifiedLoaderClone:
     def INPUT_TYPES(s):
         return {"required": {
             "model": ("MODEL", ),
-            "preset": (['LIGHT - SD1.5 only (low strength)', 'STANDARD (medium strength)', 'VIT-G (medium strength)', 'PLUS (high strength)', 'PLUS FACE (portraits)', 'FULL FACE - SD1.5 only (portraits stronger)'], ),
+            "preset": (['STANDARD (medium strength)', 'VIT-G (medium strength)', 'PLUS (high strength)'], ),
         },
         "optional": {
             "ipadapter": ("IPADAPTER", ),
@@ -134,14 +134,7 @@ def get_ipadapter_file(preset, is_sdxl):
     is_insightface = False
     lora_pattern = None
 
-    if preset.startswith("light"):
-        if is_sdxl:
-            raise Exception("light model is not supported for SDXL")
-        pattern = r'sd15.light.v11\.(safetensors|bin)$'
-        # if v11 is not found, try with the old version
-        if not [e for e in ipadapter_list if re.search(pattern, e, re.IGNORECASE)]:
-            pattern = r'sd15.light\.(safetensors|bin)$'
-    elif preset.startswith("standard"):
+    if preset.startswith("standard"):
         if is_sdxl:
             pattern = r'ip.adapter.sdxl.vit.h\.(safetensors|bin)$'
         else:
@@ -156,58 +149,6 @@ def get_ipadapter_file(preset, is_sdxl):
             pattern = r'plus.sdxl.vit.h\.(safetensors|bin)$'
         else:
             pattern = r'ip.adapter.plus.sd15\.(safetensors|bin)$'
-    elif preset.startswith("plus face"):
-        if is_sdxl:
-            pattern = r'plus.face.sdxl.vit.h\.(safetensors|bin)$'
-        else:
-            pattern = r'plus.face.sd15\.(safetensors|bin)$'
-    elif preset.startswith("full"):
-        if is_sdxl:
-            raise Exception("full face model is not supported for SDXL")
-        pattern = r'full.face.sd15\.(safetensors|bin)$'
-    elif preset.startswith("faceid portrait ("):
-        if is_sdxl:
-            pattern = r'portrait.sdxl\.(safetensors|bin)$'
-        else:
-            pattern = r'portrait.v11.sd15\.(safetensors|bin)$'
-            # if v11 is not found, try with the old version
-            if not [e for e in ipadapter_list if re.search(pattern, e, re.IGNORECASE)]:
-                pattern = r'portrait.sd15\.(safetensors|bin)$'
-        is_insightface = True
-    elif preset.startswith("faceid portrait unnorm"):
-        if is_sdxl:
-            pattern = r'portrait.sdxl.unnorm\.(safetensors|bin)$'
-        else:
-            raise Exception("portrait unnorm model is not supported for SD1.5")
-        is_insightface = True
-    elif preset == "faceid":
-        if is_sdxl:
-            pattern = r'faceid.sdxl\.(safetensors|bin)$'
-            lora_pattern = r'faceid.sdxl.lora\.safetensors$'
-        else:
-            pattern = r'faceid.sd15\.(safetensors|bin)$'
-            lora_pattern = r'faceid.sd15.lora\.safetensors$'
-        is_insightface = True
-    elif preset.startswith("faceid plus -"):
-        if is_sdxl:
-            raise Exception("faceid plus model is not supported for SDXL")
-        pattern = r'faceid.plus.sd15\.(safetensors|bin)$'
-        lora_pattern = r'faceid.plus.sd15.lora\.safetensors$'
-        is_insightface = True
-    elif preset.startswith("faceid plus v2"):
-        if is_sdxl:
-            pattern = r'faceid.plusv2.sdxl\.(safetensors|bin)$'
-            lora_pattern = r'faceid.plusv2.sdxl.lora\.safetensors$'
-        else:
-            pattern = r'faceid.plusv2.sd15\.(safetensors|bin)$'
-            lora_pattern = r'faceid.plusv2.sd15.lora\.safetensors$'
-        is_insightface = True
-    # Community's models
-    elif preset.startswith("composition"):
-        if is_sdxl:
-            pattern = r'plus.composition.sdxl\.safetensors$'
-        else:
-            pattern = r'plus.composition.sd15\.safetensors$'
     else:
         raise Exception(f"invalid type '{preset}'")
 


### PR DESCRIPTION
Removes SD1.5-only and face-oriented presets from PseudoIPAdapterUnifiedLoaderClone and their corresponding branches in get_ipadapter_file(). Keeps STANDARD, VIT-G, and PLUS only, making the node's file requirements a short enumerable list.